### PR TITLE
Ensure file URIs without a host build with slashes

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -233,7 +233,7 @@ function build(array $parts) : string {
         $uri = $parts['scheme'] . ':';
 
     }
-    if ($authority) {
+    if ($authority || (!empty($parts['scheme']) && $parts['scheme'] === 'file')) {
         // No scheme, but there is a host.
         $uri .= '//' . $authority;
 

--- a/tests/BuildTest.php
+++ b/tests/BuildTest.php
@@ -32,6 +32,8 @@ class BuildTest extends \PHPUnit_Framework_TestCase{
             ['/hi?a=b#c=d'],
             ['?a=b#c=d'],
             ['#c=d'],
+            ['file:///etc/hosts'],
+            ['file://localhost/etc/hosts'],
         ];
 
     }


### PR DESCRIPTION
If you parse a file uri without a host like `file:///etc/hosts`, it will rebuild as `file:/etc/hosts`.  This PR fixes `Uri\build` to add the missing `//` for file URIs that don't have a host.

The docs for `parse_url` say:

> This function is intended specifically for the purpose of parsing URLs and not URIs. However, to comply with PHP's backwards compatibility requirements it makes an exception for the file:// scheme where triple slashes (file:///...) are allowed. For any other scheme this is invalid.

I figure if `parse_url` supports `file://` URIs it makes sense for `Uri\build` to support them too.

I tried to find a source for the proper behavior.  RFC 3986 just says:

> For example, the "file" URI scheme is defined so that no authority, an empty host, and "localhost" all mean the end-user's machine
