### PR TITLE
Workaround for parsing colons in partial URLs

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -180,13 +180,21 @@ function normalize(string $uri) : string {
  */
 function parse(string $uri) : array {
 
+    if (preg_match('/^[a-zA-Z]*:/u', $uri) === 0) {
+        // if no protocol is given and a colon is present,
+        // we need to encode it to avoid a PHP bug
+        $replaceRegExp = '/(?:[^[:ascii:]]|:)/u';
+    } else {
+        $replaceRegExp = '/[^[:ascii:]]/u';
+    }
+
     // Normally a URI must be ASCII, however. However, often it's not and
     // parse_url might corrupt these strings.
     //
     // For that reason we take any non-ascii characters from the uri and
     // uriencode them first.
     $uri = preg_replace_callback(
-        '/[^[:ascii:]]/u',
+        $replaceRegExp,
         function($matches) {
             return rawurlencode($matches[0]);
         },

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -58,6 +58,32 @@ class ParseTest extends \PHPUnit_Framework_TestCase{
                     'fragment' => null,
                 ]
             ],
+			// See issue #9, parse_url doesn't like colons followed by numbers even
+			// though they are allowed since RFC 3986
+            [
+                'http://example.org/hello:12?foo=bar#test',
+                [
+                    'scheme'   => 'http',
+                    'host'     => 'example.org',
+                    'path'     => '/hello:12',
+                    'port'     => null,
+                    'user'     => null,
+                    'query'    => 'foo=bar',
+                    'fragment' => 'test'
+                ]
+            ],
+            [
+                '/path/to/colon:34',
+                [
+                    'scheme'   => null,
+                    'host'     => null,
+                    'path'     => '/path/to/colon%3A34',
+                    'port'     => null,
+                    'user'     => null,
+                    'query'    => null,
+                    'fragment' => null,
+                ]
+            ],
 
         ];
 


### PR DESCRIPTION
Whenever a URL contains no host part, the presence of a colon will make
PHP's parse_url fail. To workaround this bug, we need to encode the
colon in this situation.

However we do not encode colons for full URLs.

Fixes https://github.com/fruux/sabre-uri/issues/9

@evert would you accept a backport for this to the sabre-uri 1.0 series ? (not sure how to proceed, no stable branches ?)

Please review