### PR TITLE
Support Backslashes

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -180,6 +180,9 @@ function normalize($uri) {
  */
 function parse($uri) {
 
+    // Replace backslashes
+    $uri = str_replace('\\', '/', $uri);
+    
     // Normally a URI must be ASCII, however. However, often it's not and
     // parse_url might corrupt these strings.
     //
@@ -301,6 +304,9 @@ function split($path) {
  */
 function _parse_fallback($uri) {
 
+    // Replace backslashes
+    $uri = str_replace('\\', '/', $uri);
+
     // Normally a URI must be ASCII, however. However, often it's not and
     // parse_url might corrupt these strings.
     //
@@ -348,15 +354,14 @@ function _parse_fallback($uri) {
       $result['host'] = '';
     } elseif (substr($uri, 0, 2) === '//') {
         // Uris that have an authority part.
-        $regex = '
-          %^
+        $regex = '%^
             //
             (?: (?<user> [^:@]+) (: (?<pass> [^@]+)) @)?
-            (?<host> ( [^:/]* | \[ [^\]]+ \] ))
+            (?<host> ( [^:/]* | \[ [^\]]+ \] )) [:]?
             (?: : (?<port> [0-9]+))?
             (?<path> / .*)?
-          $%x
-        ';
+          $%x';
+          
         if (!preg_match($regex, $uri, $matches)) {
             throw new InvalidUriException('Invalid, or could not parse URI');
         }

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -184,6 +184,20 @@ class ParseTest extends \PHPUnit_Framework_TestCase{
                     'fragment' => 'foo',
                 ]
 
+            ],
+            // Backslashes
+            [
+                'file://C:\\abc\\x y z\\lib/dir/file.txt',
+                [
+                    'scheme'   => 'file',
+                    'host'     => 'C',
+                    'path'     => '/abc/x y z/lib/dir/file.txt',
+                    'port'     => null,
+                    'user'     => null,
+                    'query'    => null,
+                    'fragment' => null,
+                ]
+
             ]
 
         ];


### PR DESCRIPTION
Hi,

it would be nice if the library could handle paths with backslashes, because PHP doesnt really care about the slashes (http://php.net/manual/en/wrappers.file.php)

for e.g. `$uri = 'file://' . __DIR__ . '/src/data.json';` results in an `InvalidUriException` because this resolves to something like `file://C:\abc\xyz/src/data.json`

For this reason I added 
`$uri = str_replace('\\', '/', $uri);`

Furthermore the parsing couldn't handle hostnames if they are windows drives like `C:`. Therefore I expanded the Regex.

`(?<host> ( [^:/]* | \[ [^\]]+ \] )) [:]?`

This matches the `:` after the drive name if present. The test cases are ok, but I'm not sure about further side effects.

I also had to remove the white spaces before and after the regex because I couldn't get it tested otherwise (using PHP 7.1)