### PR TITLE
Windows host handling

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -197,6 +197,15 @@ function parse(string $uri) : array {
     if (!$result) {
         $result = _parse_fallback($uri);
     }
+    else
+    {
+        // Add empty host and trailing slash to windows file paths (file:///C:/path)
+        if (isset($result['scheme']) && $result['scheme'] === 'file' && isset($result['path']) &&
+             preg_match('/^(?<windows_path> [a-zA-Z]:(\/(?![\/])|\\\\)[^?]*)$/x', $result['path'])) {
+            $result['path'] = '/' . $result['path'];
+            $result['host'] = '';
+        }
+    }
 
     return
          $result + [
@@ -348,15 +357,13 @@ function _parse_fallback(string $uri) : array {
       $result['host'] = '';
     } elseif (substr($uri, 0, 2) === '//') {
         // Uris that have an authority part.
-        $regex = '
-          %^
+        $regex = '%^
             //
             (?: (?<user> [^:@]+) (: (?<pass> [^@]+)) @)?
             (?<host> ( [^:/]* | \[ [^\]]+ \] ))
             (?: : (?<port> [0-9]+))?
             (?<path> / .*)?
-          $%x
-        ';
+          $%x';
         if (!preg_match($regex, $uri, $matches)) {
             throw new InvalidUriException('Invalid, or could not parse URI');
         }

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -184,8 +184,21 @@ class ParseTest extends \PHPUnit\Framework\TestCase {
                     'fragment' => 'foo',
                 ]
 
-            ]
+            ],
+            // Windows Paths
+            [
+                'file:///C:/path/file.ext',
+                [
+                    'scheme'   => 'file',
+                    'host'     => '',
+                    'path'     => '/C:/path/file.ext',
+                    'port'     => null,
+                    'user'     => null,
+                    'query'    => null,
+                    'fragment' => null,
+                ]
 
+            ],
         ];
 
     }

--- a/tests/ResolveTest.php
+++ b/tests/ResolveTest.php
@@ -103,7 +103,12 @@ class ResolveTest extends \PHPUnit\Framework\TestCase {
                 '#',
                 'http://example.org/path.json',
             ],
-
+            // Windows Paths
+            [
+                'file:///C:/path/file_a.ext',
+                'file_b.ext',
+                'file:///C:/path/file_b.ext',
+            ],
         ];
 
     }


### PR DESCRIPTION
Hi,

I think a found a bug on windows. For the uri `'file:///C:/path/file_a.ext'` `parse` returns

```PHP
array (size=2)
  'scheme' => string 'file' (length=4)
  'path' => string 'C:/path/file_a.ext' (length=18)
```

This causes `resolve('file:///C:/path/file_a.ext', 'file_b.ext')` to generate wrong URIs:
`file://C:/path/file_b.ext` (one slash is missing, because the empty host is missing).

`parse_url` produces the same result, which is correct with reagards to http://php.net/manual/en/wrappers.file.php, but it cannot be used to reconstruct file uris directly.

The behavior of `_parse_fallback` is correct and has this output:

```PHP
array (size=3)
  'scheme' => string 'file' (length=4)
  'path' => string '/C:/path/file_a.ext' (length=19)
  'host' => string '' (length=0)
```

`parse` should also produce this output.

Note: I had to remove the white spaces before and after the regex because I couldn't get it tested otherwise (using PHP 7.1)