### PR TITLE
Document InvalidUriException

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -22,6 +22,8 @@ namespace Sabre\Uri;
  * @param string $newPath
  *
  * @return string
+ *
+ * @throws InvalidUriException
  */
 function resolve(string $basePath, string $newPath): string
 {
@@ -113,6 +115,8 @@ function resolve(string $basePath, string $newPath): string
  * @param string $uri
  *
  * @return string
+ *
+ * @throws InvalidUriException
  */
 function normalize(string $uri): string
 {
@@ -182,6 +186,8 @@ function normalize(string $uri): string
  * @param string $uri
  *
  * @return array
+ *
+ * @throws InvalidUriException
  */
 function parse(string $uri): array
 {
@@ -302,6 +308,8 @@ function split(string $path): array
  * @param string $uri
  *
  * @return array
+ *
+ * @throws InvalidUriException
  */
 function _parse_fallback(string $uri): array
 {


### PR DESCRIPTION
`_parse_fallback()`, together with functions that directly or indirectly call it, are missing `@throws` in their respective docblocks.

This is annoying for static analysis, for example PHPStorm tells me:

![image](https://user-images.githubusercontent.com/1952838/59350756-31c3e300-8d1d-11e9-9df2-07d697c628e7.png)

This PR adds `@throws` where appropriate.