### PR TITLE
Fix undefined port error in parse function, when the port was not found.

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -373,7 +373,7 @@ function _parse_fallback(string $uri): array
         if ($matches['host']) {
             $result['host'] = $matches['host'];
         }
-        if ($matches['port']) {
+        if (isset($matches['port'])) {
             $result['port'] = (int) $matches['port'];
         }
         if (isset($matches['path'])) {

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -192,6 +192,30 @@ class ParseTest extends \PHPUnit\Framework\TestCase
                     'fragment' => 'foo',
                 ],
             ],
+            [
+                'https://',
+                [
+                    'scheme' => 'https',
+                    'host' => null,
+                    'path' => null,
+                    'port' => null,
+                    'user' => null,
+                    'query' => null,
+                    'fragment' => null,
+                ],
+            ],
+            [
+                'https://test',
+                [
+                    'scheme' => 'https',
+                    'host' => 'test',
+                    'path' => null,
+                    'port' => null,
+                    'user' => null,
+                    'query' => null,
+                    'fragment' => null,
+                ],
+            ]
         ];
     }
 }

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -215,7 +215,7 @@ class ParseTest extends \PHPUnit\Framework\TestCase
                     'query' => null,
                     'fragment' => null,
                 ],
-            ]
+            ],
         ];
     }
 }


### PR DESCRIPTION
For example, if we pass 'https://' to parse function, this would throw undefined index error previously. Fixes #41 