### PR TITLE
Allow to use 0 in path

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -53,7 +53,7 @@ function resolve(string $basePath, string $newPath): string
     $newParts['port'] = $pick('port');
 
     $path = '';
-    if ($delta['path']) {
+    if (is_string($delta['path']) and strlen($delta['path']) > 0) {
         // If the path starts with a slash
         if ('/' === $delta['path'][0]) {
             $path = $delta['path'];

--- a/tests/ResolveTest.php
+++ b/tests/ResolveTest.php
@@ -104,6 +104,12 @@ class ResolveTest extends \PHPUnit\Framework\TestCase
                 '#',
                 'http://example.org/path.json',
             ],
+            // Allow to use 0 in path
+            [
+                'http://example.org/',
+                '0',
+                'http://example.org/0',
+            ],
         ];
     }
 }


### PR DESCRIPTION
I found a problem in https://github.com/sabre-io/dav component.

I cannot create a directory with name `http://example.com/0` because it casts into `http://example.com`

Can you please update both extensions?

Thank you!
