### PR TITLE
Bump phpstan to 0.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 vendor/
 composer.lock
 
+# Composer binaries
+bin/phpunit
+bin/phpstan
+bin/phpstan.phar
+bin/php-cs-fixer
+
 # Tests
 tests/cov/
 
@@ -10,6 +16,9 @@ bin
 
 # Vim
 .*.swp
+
+# IDEs
+/.idea
 
 # development stuff
 .php_cs.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
   fast_finish: true
 
 install:
-  - if [ $RUN_PHPSTAN == "TRUE"  ]; then wget https://github.com/phpstan/phpstan/releases/download/0.10.3/phpstan.phar; fi
+  - if [ $RUN_PHPSTAN == "TRUE"  ]; then composer require --dev phpstan/phpstan:^0.12; fi
 
 before_script:
   - rm -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
@@ -27,7 +27,7 @@ before_script:
 
 script:
   - if [ $RUN_PHPSTAN == "FALSE"  ]; then ./bin/phpunit --configuration tests/phpunit.xml.dist --coverage-clover=coverage.xml; fi
-  - if [ $RUN_PHPSTAN == "TRUE"  ]; then php phpstan.phar analyse -c phpstan.neon lib; fi
+  - if [ $RUN_PHPSTAN == "TRUE"  ]; then php ./bin/phpstan analyse -c phpstan.neon lib; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -185,7 +185,7 @@ function normalize(string $uri): string
  *
  * @param string $uri
  *
- * @return array
+ * @return array<string, string>
  *
  * @throws InvalidUriException
  */
@@ -225,7 +225,7 @@ function parse(string $uri): array
  * This function takes the components returned from PHP's parse_url, and uses
  * it to generate a new uri.
  *
- * @param array $parts
+ * @param array<string, string> $parts
  *
  * @return string
  */
@@ -283,7 +283,7 @@ function build(array $parts): string
  *
  * @param string $path
  *
- * @return array
+ * @return array<int, mixed>
  */
 function split(string $path): array
 {
@@ -307,7 +307,7 @@ function split(string $path): array
  *
  * @param string $uri
  *
- * @return array
+ * @return array<string, mixed>
  *
  * @throws InvalidUriException
  */


### PR DESCRIPTION
and enhance some PHPdoc to keep phpstan happy.

phpstan was fussing about:
```
 ------ ----------------------------------------------------------------------- 
  Line   functions.php                                                          
 ------ ----------------------------------------------------------------------- 
  192    Function Sabre\Uri\parse() return type has no value type specified in  
         iterable type array.                                                   
         💡 Consider adding something like array<Foo> to the                     
         PHPDoc.                                                                
         You can turn off this check by setting                                 
         checkMissingIterableValueType: false in your                           
         /home/travis/build/sabre-io/uri/phpstan.neon.                          

  232    Function Sabre\Uri\build() has parameter $parts with no value type     
         specified in iterable type array.                                      
         m💡 Consider adding something like array<Foo> to the                     
         PHPDoc.                                                                
         You can turn off this check by setting                                 
         checkMissingIterableValueType: false in your                           
         /home/travis/build/sabre-io/uri/phpstan.neon.                          

  288    Function Sabre\Uri\split() return type has no value type specified in  
         iterable type array.                                                   

         💡 Consider adding something like array<Foo> to the                     
         PHPDoc.                                                                
         You can turn off this check by setting                                 
         checkMissingIterableValueType: false in your                           
         /home/travis/build/sabre-io/uri/phpstan.neon.                          

  314    Function Sabre\Uri\_parse_fallback() return type has no value type     

         specified in iterable type array.                                      
         💡 Consider adding something like array<Foo> to the                     
         PHPDoc.                                                                
         You can turn off this check by setting                                 
         checkMissingIterableValueType: false in your                           
         /home/travis/build/sabre-io/uri/phpstan.neon.                          
 ------ ----------------------------------------------------------------------- 
                                                                              
 [ERROR] Found 4 errors                                                         
```
