### PR TITLE
Drop php 7.0 and bump phpunit to v7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ bin/php-cs-fixer
 
 # Tests
 tests/cov/
+coverage.xml
 
 # Composer binaries
 bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 sudo: required
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "homepage": "http://sabre.io/uri/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=7"
+        "php": "^7.1"
     },
     "authors": [
         {
@@ -37,7 +37,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit" : "^6"
+        "phpunit/phpunit" : "^7"
     },
     "config" : {
         "bin-dir" : "bin/"

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -4,11 +4,14 @@
   convertErrorsToExceptions="true"
   convertNoticesToExceptions="true"
   convertWarningsToExceptions="true"
-  strict="true"
+  beStrictAboutTestsThatDoNotTestAnything="true"
+  beStrictAboutOutputDuringTests="true"
   >
-  <testsuite name="sabre-uri">
-    <directory>.</directory>
-  </testsuite>
+  <testsuites>
+    <testsuite name="sabre-uri">
+      <directory>.</directory>
+    </testsuite>
+  </testsuites>
 
   <filter>
     <whitelist addUncoveredFilesFromWhitelist="true">


### PR DESCRIPTION
- drop php 7.0
- bump phpunit to v7

IMO we can easily just drop PHP 7.0 in each repo (which is now "very old"), and keep 7.1 for a few more months/weeks since it is still supported for a little while by applications such as ownCloud. 

(I can do a PR like this in each repo that has not yet dropped PHP 7.0 support)