### PR TITLE
Standardize CI 20200203

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,25 +2,7 @@
 vendor/
 composer.lock
 
-# Composer binaries
-bin/phpunit
-bin/phpstan
-bin/phpstan.phar
-bin/php-cs-fixer
-
 # Tests
 tests/cov/
 tests/.phpunit.result.cache
-coverage.xml
-
-# Composer binaries
-bin
-
-# Vim
-.*.swp
-
-# IDEs
-/.idea
-
-# development stuff
 .php_cs.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,25 +9,25 @@ php:
 env:
   global:
     - RUN_PHPSTAN="FALSE"
+  matrix:
+    - PREFER_LOWEST="" WITH_COVERAGE="--coverage-clover=coverage.xml"
+    - PREFER_LOWEST="--prefer-lowest" $WITH_COVERAGE=""
 
 matrix:
   include:
     - name: 'PHPStan'
-      php: 7.2
+      php: 7.4
       env: RUN_PHPSTAN="TRUE"
   fast_finish: true
 
-install:
-  - if [ $RUN_PHPSTAN == "TRUE"  ]; then composer require --dev phpstan/phpstan:^0.12; fi
-
 before_script:
+  - composer update --prefer-source $PREFER_LOWEST
   - rm -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
-  - composer install
 
 script:
-  - if [ $RUN_PHPSTAN == "FALSE"  ]; then ./bin/php-cs-fixer  fix --dry-run --diff; fi
-  - if [ $RUN_PHPSTAN == "FALSE"  ]; then ./bin/phpunit --configuration tests/phpunit.xml --coverage-clover=coverage.xml; fi
-  - if [ $RUN_PHPSTAN == "TRUE"  ]; then php ./bin/phpstan analyse -c phpstan.neon lib; fi
+  - if [ $RUN_PHPSTAN == "FALSE" ]; then php vendor/bin/php-cs-fixer fix --dry-run --diff; fi
+  - if [ $RUN_PHPSTAN == "FALSE" ]; then php vendor/bin/phpunit --configuration tests/phpunit.xml $WITH_COVERAGE; fi
+  - if [ $RUN_PHPSTAN == "TRUE" ]; then php vendor/bin/phpstan analyse -c phpstan.neon lib tests; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/composer.json
+++ b/composer.json
@@ -33,14 +33,28 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Sabre\\Uri\\": "tests/"
+            "Sabre\\Uri\\": "tests/Uri"
         }
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.16.1",
+        "phpstan/phpstan": "^0.12",
         "phpunit/phpunit" : "^7 || ^8"
     },
-    "config" : {
-        "bin-dir" : "bin/"
+    "scripts": {
+        "phpstan": [
+            "@php vendor/bin/phpstan analyse lib tests"
+        ],
+        "cs-fixer": [
+            "@php vendor/bin/php-cs-fixer fix"
+        ],
+        "phpunit": [
+            "@php vendor/bin/phpunit --configuration tests/phpunit.xml"
+        ],
+        "test": [
+            "composer phpstan",
+            "composer cs-fixer",
+            "composer phpunit"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.16.1",
         "phpstan/phpstan": "^0.12",
-        "phpunit/phpunit" : "^7 || ^8"
+        "phpunit/phpunit" : "^7.5 || ^8.5"
     },
     "scripts": {
         "phpstan": [

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -214,7 +214,7 @@ function parse(string $uri): array
  * This function takes the components returned from PHP's parse_url, and uses
  * it to generate a new uri.
  *
- * @param array<string, string> $parts
+ * @param array<string, int|string> $parts
  */
 function build(array $parts): string
 {

--- a/tests/Uri/BuildTest.php
+++ b/tests/Uri/BuildTest.php
@@ -8,15 +8,23 @@ class BuildTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider buildUriData
+     *
+     * @param string $value
      */
-    public function testBuild($value)
+    public function testBuild($value): void
     {
+        /** @var array<string, int|string> $parsedUrl */
+        $parsedUrl = parse_url($value);
+        $this->assertIsArray($parsedUrl);
         $this->assertEquals(
             $value,
-            build(parse_url($value))
+            build($parsedUrl)
         );
     }
 
+    /**
+     * @return array<int, array<int, string>>
+     */
     public function buildUriData()
     {
         return [

--- a/tests/Uri/NormalizeTest.php
+++ b/tests/Uri/NormalizeTest.php
@@ -8,8 +8,11 @@ class NormalizeTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider normalizeData
+     *
+     * @param string $in
+     * @param string $out
      */
-    public function testNormalize($in, $out)
+    public function testNormalize($in, $out): void
     {
         $this->assertEquals(
             $out,
@@ -17,6 +20,9 @@ class NormalizeTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    /**
+     * @return array<int, array<int, string>>
+     */
     public function normalizeData()
     {
         return [

--- a/tests/Uri/ParseTest.php
+++ b/tests/Uri/ParseTest.php
@@ -8,8 +8,11 @@ class ParseTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider parseData
+     *
+     * @param string $in
+     * @param string $out
      */
-    public function testParse($in, $out)
+    public function testParse($in, $out): void
     {
         $this->assertEquals(
             $out,
@@ -19,8 +22,11 @@ class ParseTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider parseData
+     *
+     * @param string $in
+     * @param string $out
      */
-    public function testParseFallback($in, $out)
+    public function testParseFallback($in, $out): void
     {
         $result = _parse_fallback($in);
         $result = $result + [
@@ -39,7 +45,7 @@ class ParseTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testParseFallbackShouldThrowInvalidUriException()
+    public function testParseFallbackShouldThrowInvalidUriException(): void
     {
         $this->expectException(\Sabre\Uri\InvalidUriException::class);
         $this->expectExceptionMessage('Invalid, or could not parse URI');
@@ -47,7 +53,10 @@ class ParseTest extends \PHPUnit\Framework\TestCase
         _parse_fallback('ssh://invalid::7000/hello?foo=bar#test');
     }
 
-    public function parseData()
+    /**
+     * @return array<int, array<int, string|array>>
+     */
+    public function parseData(): array
     {
         return [
             [

--- a/tests/Uri/ResolveTest.php
+++ b/tests/Uri/ResolveTest.php
@@ -8,8 +8,14 @@ class ResolveTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider resolveData
+     *
+     * @param string $base
+     * @param string $update
+     * @param string $expected
+     *
+     * @throws InvalidUriException
      */
-    public function testResolve($base, $update, $expected)
+    public function testResolve($base, $update, $expected): void
     {
         $this->assertEquals(
             $expected,
@@ -17,7 +23,10 @@ class ResolveTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function resolveData()
+    /**
+     * @return array<int, array<int, string>>
+     */
+    public function resolveData(): array
     {
         return [
             [

--- a/tests/Uri/SplitTest.php
+++ b/tests/Uri/SplitTest.php
@@ -6,7 +6,7 @@ namespace Sabre\Uri;
 
 class SplitTest extends \PHPUnit\Framework\TestCase
 {
-    public function testSplit()
+    public function testSplit(): void
     {
         $strings = [
             // input                    // expected result


### PR DESCRIPTION
- cleanup `.gitignore`
- implement Travis like in `skel` (separate `phpstan` job, `--prefer-lowest` in matrix)
- implement composer like in `skel`
- adjust PHPdoc and function return types of test code to keep `phpstan` happy
- `lib/functions.php` `build()` can take `int` or `string` in the `$parts` array (e.g. port is `80`). Adjust the PHPdoc to reflect that (keeps `phpstan` happy, is true, and does not crash any tests)
- require at least `phpunit` `7.5` so that we are sure to have `assertIsArray()` (it is not in `phpunit` 7.0) as was done in `skel` https://github.com/sabre-io/skel/pull/12