### PR TITLE
Add empty host and trailing slash to windows file paths

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -197,9 +197,15 @@ function parse(string $uri): array
     if (!$result) {
         $result = _parse_fallback($uri);
     } else {
-        // Add empty host and trailing slash to Windows file paths (file:///C:/path)
+        // Add empty host and trailing slash to Windows file paths
+        // file:///C:/path or file:///C:\path
+        // Note: the regex fragment [a-zA-Z]:[\/\\\\].* end up being
+        // [a-zA-Z]:[\/\\].*
+        // The 4 backslash in a row are the way to get 2 backslash into the actual string
+        // that is used as the regex. The 2 backslash are then the way to get 1 backslash
+        // character into the character set "a forward slash or a backslash"
         if (isset($result['scheme']) && 'file' === $result['scheme'] && isset($result['path']) &&
-             preg_match('/^(?<windows_path> [a-zA-Z]:(\/(?![\/])|\\\\)[^?]*)$/x', $result['path'])) {
+             preg_match('/^(?<windows_path> [a-zA-Z]:[\/\\\\].*)$/x', $result['path'])) {
             $result['path'] = '/'.$result['path'];
             $result['host'] = '';
         }

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -205,7 +205,7 @@ function parse(string $uri): array
         // that is used as the regex. The 2 backslash are then the way to get 1 backslash
         // character into the character set "a forward slash or a backslash"
         if (isset($result['scheme']) && 'file' === $result['scheme'] && isset($result['path']) &&
-             preg_match('/^(?<windows_path> [a-zA-Z]:[\/\\\\].*)$/x', $result['path'])) {
+             preg_match('/^(?<windows_path> [a-zA-Z]:([\/\\\\].*)?)$/x', $result['path'])) {
             $result['path'] = '/'.$result['path'];
             $result['host'] = '';
         }

--- a/tests/Uri/ParseTest.php
+++ b/tests/Uri/ParseTest.php
@@ -238,6 +238,18 @@ class ParseTest extends \PHPUnit\Framework\TestCase
                     'fragment' => null,
                 ],
             ],
+            [
+                'file:///C:\path\file.ext',
+                [
+                    'scheme' => 'file',
+                    'host' => '',
+                    'path' => '/C:\path\file.ext',
+                    'port' => null,
+                    'user' => null,
+                    'query' => null,
+                    'fragment' => null,
+                ],
+            ],
         ];
     }
 }

--- a/tests/Uri/ParseTest.php
+++ b/tests/Uri/ParseTest.php
@@ -250,6 +250,18 @@ class ParseTest extends \PHPUnit\Framework\TestCase
                     'fragment' => null,
                 ],
             ],
+            [
+                'file:///C:',
+                [
+                    'scheme' => 'file',
+                    'host' => '',
+                    'path' => '/C:',
+                    'port' => null,
+                    'user' => null,
+                    'query' => null,
+                    'fragment' => null,
+                ],
+            ],
         ];
     }
 }

--- a/tests/Uri/ParseTest.php
+++ b/tests/Uri/ParseTest.php
@@ -225,6 +225,19 @@ class ParseTest extends \PHPUnit\Framework\TestCase
                     'fragment' => null,
                 ],
             ],
+            // Windows Paths
+            [
+                'file:///C:/path/file.ext',
+                [
+                    'scheme' => 'file',
+                    'host' => '',
+                    'path' => '/C:/path/file.ext',
+                    'port' => null,
+                    'user' => null,
+                    'query' => null,
+                    'fragment' => null,
+                ],
+            ],
         ];
     }
 }

--- a/tests/Uri/ResolveTest.php
+++ b/tests/Uri/ResolveTest.php
@@ -125,6 +125,12 @@ class ResolveTest extends \PHPUnit\Framework\TestCase
                 '0',
                 'http://example.org/0',
             ],
+            // Windows Paths
+            [
+                'file:///C:/path/file_a.ext',
+                'file_b.ext',
+                'file:///C:/path/file_b.ext',
+            ],
         ];
     }
 }


### PR DESCRIPTION
This is a rebase of PR #25 with conflicts resolved...

In the 2nd commit, I have added some comments and simplified the windows_path regex in a similar way to what @peterpostmann has suggested in comment https://github.com/sabre-io/uri/pull/25#discussion_r946370109
