### PR TITLE
Bump phpstan to 1.8.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.17.1",
-        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan": "^1.8",
         "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.0"
     },
     "scripts": {

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -309,6 +309,10 @@ function _parse_fallback(string $uri): array
         $uri
     );
 
+    if ($uri === null) {
+        throw new InvalidUriException('Invalid, or could not parse URI');
+    }
+
     $result = [
         'scheme' => null,
         'host' => null,

--- a/tests/Uri/ParseTest.php
+++ b/tests/Uri/ParseTest.php
@@ -54,7 +54,7 @@ class ParseTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array<int, array<int, string|array>>
+     * @return array<int, array<int, array<string, int|string|null>|string>>
      */
     public function parseData(): array
     {


### PR DESCRIPTION
WIP - phpstan 1.8 is for PHP 7.2 and up - probably best to not bother with this until we drop support for older PHP.