### PR TITLE
Use latest php-cs-fixer of major version 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.17.1",
+        "friendsofphp/php-cs-fixer": "~2.19.3",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.0"
     },


### PR DESCRIPTION
Use php-cs-fixer 2.19.3 upwards (in the v2 series). We might as well use the latest of that series, before starting the process to drop older PHP versions etc.
