### PR TITLE
Minimum PHP 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php-versions: ['8.0', '8.1']
         coverage: ['pcov']
         code-analysis: ['no']
         include:
-          - php-versions: '7.1'
+          - php-versions: '7.4'
             coverage: 'none'
             code-analysis: 'yes'
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 tests/cov/
 tests/.phpunit.result.cache
 .php_cs.cache
+.php-cs-fixer.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,12 +1,13 @@
 <?php
 
-$config = PhpCsFixer\Config::create();
-$config->getFinder()
+$finder = PhpCsFixer\Finder::create()
     ->exclude('vendor')
     ->in(__DIR__);
+
+$config = new PhpCsFixer\Config();
 $config->setRules([
     '@PSR1' => true,
     '@Symfony' => true
 ]);
-
+$config->setFinder($finder);
 return $config;

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.19.3",
-        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan": "^1.8",
         "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.0"
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "homepage": "http://sabre.io/uri/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": "^7.1 || ^8.0"
+        "php": "^7.4 || ^8.0"
     },
     "authors": [
         {
@@ -39,7 +39,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.19.3",
         "phpstan/phpstan": "^1.8",
-        "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.0"
+        "phpunit/phpunit" : "^9.0"
     },
     "scripts": {
         "phpstan": [

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.19.3",
+        "friendsofphp/php-cs-fixer": "^3.9",
         "phpstan/phpstan": "^1.8",
         "phpunit/phpunit" : "^9.0"
     },

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    const VERSION = '2.2.3';
+    public const VERSION = '2.3.0';
 }

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -69,7 +69,7 @@ function resolve(string $basePath, string $newPath): string
     $newPathParts = [];
     foreach ($pathParts as $pathPart) {
         switch ($pathPart) {
-            //case '' :
+            // case '' :
             case '.':
                 break;
             case '..':

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -322,6 +322,10 @@ function _parse_fallback(string $uri): array
         $uri
     );
 
+    if (null === $uri) {
+        throw new InvalidUriException('Invalid, or could not parse URI');
+    }
+
     $result = [
         'scheme' => null,
         'host' => null,

--- a/tests/Uri/BuildTest.php
+++ b/tests/Uri/BuildTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Sabre\Uri;
 
-class BuildTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class BuildTest extends TestCase
 {
     /**
      * @dataProvider buildUriData
-     *
-     * @param string $value
      */
-    public function testBuild($value): void
+    public function testBuild(string $value): void
     {
         /** @var array<string, int|string> $parsedUrl */
         $parsedUrl = parse_url($value);
@@ -25,7 +25,7 @@ class BuildTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public function buildUriData()
+    public function buildUriData(): array
     {
         return [
             ['http://example.org/'],

--- a/tests/Uri/NormalizeTest.php
+++ b/tests/Uri/NormalizeTest.php
@@ -41,7 +41,7 @@ class NormalizeTest extends \PHPUnit\Framework\TestCase
             ['http://example.org:80/',          'http://example.org/'],
             // See issue #6. parse_url corrupts strings like this, but only on
             // macs.
-            //[ 'http://example.org/有词法别名.zh','http://example.org/%E6%9C%89%E8%AF%8D%E6%B3%95%E5%88%AB%E5%90%8D.zh'],
+            // [ 'http://example.org/有词法别名.zh','http://example.org/%E6%9C%89%E8%AF%8D%E6%B3%95%E5%88%AB%E5%90%8D.zh'],
         ];
     }
 }

--- a/tests/Uri/NormalizeTest.php
+++ b/tests/Uri/NormalizeTest.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace Sabre\Uri;
 
-class NormalizeTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class NormalizeTest extends TestCase
 {
     /**
      * @dataProvider normalizeData
-     *
-     * @param string $in
-     * @param string $out
      */
-    public function testNormalize($in, $out): void
+    public function testNormalize(string $in, string $out): void
     {
         $this->assertEquals(
             $out,
@@ -23,7 +22,7 @@ class NormalizeTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public function normalizeData()
+    public function normalizeData(): array
     {
         return [
             ['https://example.org/',            'https://example.org/'],

--- a/tests/Uri/ParseTest.php
+++ b/tests/Uri/ParseTest.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace Sabre\Uri;
 
-class ParseTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class ParseTest extends TestCase
 {
     /**
      * @dataProvider parseData
      *
-     * @param string $in
-     * @param string $out
+     * @param array<int, array<int, array<string, int|string|null>|string>> $out
      */
-    public function testParse($in, $out): void
+    public function testParse(string $in, array $out): void
     {
         $this->assertEquals(
             $out,
@@ -23,10 +24,9 @@ class ParseTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider parseData
      *
-     * @param string $in
-     * @param string $out
+     * @param array<int, array<int, array<string, int|string|null>|string>> $out
      */
-    public function testParseFallback($in, $out): void
+    public function testParseFallback(string $in, array $out): void
     {
         $result = _parse_fallback($in);
         $result = $result + [

--- a/tests/Uri/ParseTest.php
+++ b/tests/Uri/ParseTest.php
@@ -54,7 +54,7 @@ class ParseTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array<int, array<int, string|array>>
+     * @return array<int, array<int, array<string, int|string|null>|string>>
      */
     public function parseData(): array
     {

--- a/tests/Uri/ResolveTest.php
+++ b/tests/Uri/ResolveTest.php
@@ -4,18 +4,16 @@ declare(strict_types=1);
 
 namespace Sabre\Uri;
 
-class ResolveTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class ResolveTest extends TestCase
 {
     /**
      * @dataProvider resolveData
      *
-     * @param string $base
-     * @param string $update
-     * @param string $expected
-     *
      * @throws InvalidUriException
      */
-    public function testResolve($base, $update, $expected): void
+    public function testResolve(string $base, string $update, string $expected): void
     {
         $this->assertEquals(
             $expected,

--- a/tests/Uri/SplitTest.php
+++ b/tests/Uri/SplitTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Sabre\Uri;
 
-class SplitTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class SplitTest extends TestCase
 {
     public function testSplit(): void
     {


### PR DESCRIPTION
This makes PHP 7.4 the minimum version of PHP.

I am doing this first in sabre-io/uri because it is at the bottom of the dependency tree, so it can happen first, and then other sabre-io repos can make use of it as they do similar.

Note: I don't see any real code changes that would cause any sort of incompatibility for current consumers of major v2 of this repo. I have only had to touch tool configs, parameter types in test code, and setting "public const" in 1 place. I don't think that any of that will be visible/noticeable to real consumers of this code. So probably we do not need to bump the major version in this repo. The "real" code is in `lib/functions.php` and that already has parameter and return types declared, and it is not a class, so there are no class variables etc to add type declarations...

Just a bump from 2.2.3 to 2.3.0 should be fine.

composer will be smart enough to only select 2.3.0 for projects that have min PHP 7.4 specified. On projects that still support PHP 7.1 7.2 or 7.3, composer will only offer/install release 2.2.3.

Note: in other repos that have more "real" code that needs touching, we will likely need to bump the major version.