### PR TITLE
Raise phpstan to level 8

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -180,7 +180,7 @@ function normalize(string $uri): string
  */
 function parse(string $uri): array
 {
-    // Normally a URI must be ASCII, however. However, often it's not and
+    // Normally a URI must be ASCII. However, often it's not and
     // parse_url might corrupt these strings.
     //
     // For that reason we take any non-ascii characters from the uri and
@@ -192,6 +192,10 @@ function parse(string $uri): array
         },
         $uri
     );
+
+    if (null === $uri) {
+        throw new InvalidUriException('Invalid, or could not parse URI');
+    }
 
     $result = parse_url($uri);
     if (!$result) {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,2 @@
 parameters:
-  level: 7
+  level: 8


### PR DESCRIPTION
and handle the (unusual) case where the result of `preg_replace_callback` could be `null`. We do not want to call `parse_url` with a null - that expects a string.

The `InvalidUriException` is thrown in the same way as is done in `_parse_fallback` - we are just doing it a bit earlier in this unusual case that phpstan level 7 noticed. Callers are already expecting that `InvalidUriException` can be thrown, so there is no change to external behavior.