### PR TITLE
Specify detailed return type of parse()

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -174,7 +174,10 @@ function normalize(string $uri): string
  * Unlike PHP's parse_url, it will also convert any non-ascii characters to
  * percent-encoded strings. PHP's parse_url corrupts these characters on OS X.
  *
- * @return array<string, string>
+ * In the return array, key "port" is an int value. Other keys have a string value.
+ * "Unused" keys have value null.
+ *
+ * @return array<string, mixed>
  *
  * @throws InvalidUriException
  */

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -54,8 +54,8 @@ function resolve(string $basePath, string $newPath): string
             $path = $delta['path'];
         } else {
             // Removing last component from base path.
-            $path = $base['path'];
-            $length = strrpos((string) $path, '/');
+            $path = (string) $base['path'];
+            $length = strrpos($path, '/');
             if (false !== $length) {
                 $path = substr($path, 0, $length);
             }
@@ -177,7 +177,7 @@ function normalize(string $uri): string
  * In the return array, key "port" is an int value. Other keys have a string value.
  * "Unused" keys have value null.
  *
- * @return array<string, mixed>
+ * @return array{scheme: string|null, host: string|null, path: string|null, port: int|null, user: string|null, query: string|null, fragment: string|null}
  *
  * @throws InvalidUriException
  */
@@ -218,6 +218,16 @@ function parse(string $uri): array
         }
     }
 
+    /*
+     * phpstan is not able to process all the things that happen while this function
+     * constructs the result array. It only understands the $result is
+     * non-empty-array<string, mixed>
+     *
+     * But the detail of the returned array is correctly specified in the PHPdoc
+     * above the function call.
+     *
+     * @phpstan-ignore-next-line
+     */
     return
          $result + [
             'scheme' => null,

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -177,7 +177,7 @@ function normalize(string $uri): string
  * In the return array, key "port" is an int value. Other keys have a string value.
  * "Unused" keys have value null.
  *
- * @return array{scheme: string|null, host: string|null, path: string|null, port: int|null, user: string|null, query: string|null, fragment: string|null}
+ * @return array{scheme: string|null, host: string|null, path: string|null, port: positive-int|null, user: string|null, query: string|null, fragment: string|null}
  *
  * @throws InvalidUriException
  */

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,2 @@
 parameters:
-  level: 8
+  level: 9


### PR DESCRIPTION
If I increase phpstan level to 9, then it detects that `function parse(string $uri): array` can return `array<string, int|string|null>` and that is correct.

Key "port" is an int value. Other keys have a string value. "Unused" keys have value null.

If I actually document:
```
 * @return array<string, int|string|null>
```

Then phpstan complains about:
```
------ ------------------------------------------------------------------------------------------------- 
  Line   lib/functions.php                                                                                
 ------ ------------------------------------------------------------------------------------------------- 
  60     Parameter #1 $string of function substr expects string, int|string|null given.                   
  68     Parameter #2 $str of function explode expects string, int<min, -1>|int<1, max>|string given.     
  117    Parameter #1 $str of function ltrim expects string, int<min, -1>|int<1, max>|string given.       
  138    Parameter #1 $str of function strtolower expects string, int<min, -1>|int<1, max>|string given.  
  161    Parameter #1 $str of function strtolower expects string, int<min, -1>|int<1, max>|string given.  
 ------ ------------------------------------------------------------------------------------------------- 
```
because it has not been told the detail that:
Key "port" can have value `int|null`
All other keys have value `string|null`

If there is some way to express this in PHPdoc, then that would be good - because the line numbers above are processing keys that do not have `int` value.

For now, I set the type of the keys to `mixed` - at least that recognizes that the values are definitely not all string.