### PR TITLE
Add empty host and leading slash to Windows file paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ChangeLog
 =========
 
+3.0.0 (2022-09-20)
+------------------
+
+* #82: Add empty host and leading slash to windows file paths (@peterpostmann @phil-davis)
+
 2.3.2 (2022-09-19)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The library provides the following functions:
 
 1. `resolve` to resolve relative urls.
 2. `normalize` to aid in comparing urls.
-3. `parse`, which works like PHP's [parse_url][6].
+3. `parse`, which works like PHP's [parse_url][6] with special cases for some Windows-style paths [9].
 4. `build` to do the exact opposite of `parse`.
 5. `split` to easily get the 'dirname' and 'basename' of a URL without all the
    problems those two functions have.
@@ -54,3 +54,4 @@ This library is being developed by [fruux](https://fruux.com/). Drop us a line f
 [6]: http://php.net/manual/en/function.parse-url.php
 [7]: http://sabre.io/uri/install/
 [8]: http://sabre.io/uri/usage/
+[9]: https://github.com/sabre-io/uri/pull/71

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    public const VERSION = '2.3.2';
+    public const VERSION = '3.0.0';
 }

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -203,6 +203,19 @@ function parse(string $uri): array
     $result = parse_url($uri);
     if (!$result) {
         $result = _parse_fallback($uri);
+    } else {
+        // Add empty host and leading slash to Windows file paths
+        // file:///C:/path or file:///C:\path
+        // Note: the regex fragment [a-zA-Z]:[\/\\\\].* end up being
+        // [a-zA-Z]:[\/\\].*
+        // The 4 backslash in a row are the way to get 2 backslash into the actual string
+        // that is used as the regex. The 2 backslash are then the way to get 1 backslash
+        // character into the character set "a forward slash or a backslash"
+        if (isset($result['scheme']) && 'file' === $result['scheme'] && isset($result['path']) &&
+            preg_match('/^(?<windows_path> [a-zA-Z]:([\/\\\\].*)?)$/x', $result['path'])) {
+            $result['path'] = '/'.$result['path'];
+            $result['host'] = '';
+        }
     }
 
     /*

--- a/tests/Uri/ParseTest.php
+++ b/tests/Uri/ParseTest.php
@@ -10,7 +10,7 @@ class ParseTest extends TestCase
 {
     /**
      * @dataProvider parseData
-     * @dataProvider windowsFormatTestCasesForParse
+     * @dataProvider windowsFormatTestCases
      *
      * @param array<int, array<int, array<string, int|string|null>|string>> $out
      */
@@ -24,7 +24,7 @@ class ParseTest extends TestCase
 
     /**
      * @dataProvider parseData
-     * @dataProvider windowsFormatTestCasesForParseFallback
+     * @dataProvider windowsFormatTestCases
      *
      * @param array<int, array<int, array<string, int|string|null>|string>> $out
      */
@@ -233,7 +233,7 @@ class ParseTest extends TestCase
     /**
      * @return array<int, array<int, array<string, int|string|null>|string>>
      */
-    public function windowsFormatTestCasesForParseFallback(): array
+    public function windowsFormatTestCases(): array
     {
         return [
             [
@@ -266,58 +266,6 @@ class ParseTest extends TestCase
                     'scheme' => 'file',
                     'host' => '',
                     'path' => '/C:',
-                    'port' => null,
-                    'user' => null,
-                    'query' => null,
-                    'fragment' => null,
-                ],
-            ],
-        ];
-    }
-
-    /**
-     * These test cases demonstrate that the parse() function does not
-     * return a "/" at the start of the path for URIs of the form
-     * file:///C:/something...
-     *
-     * See issue comment https://github.com/sabre-io/uri/pull/71#issuecomment-1250724859
-     * and gthe linked issues and PRs.
-     *
-     * @return array<int, array<int, array<string, int|string|null>|string>>
-     */
-    public function windowsFormatTestCasesForParse(): array
-    {
-        return [
-            [
-                'file:///C:/path/file.ext',
-                [
-                    'scheme' => 'file',
-                    'host' => '',
-                    'path' => 'C:/path/file.ext',
-                    'port' => null,
-                    'user' => null,
-                    'query' => null,
-                    'fragment' => null,
-                ],
-            ],
-            [
-                'file:///C:\path\file.ext',
-                [
-                    'scheme' => 'file',
-                    'host' => '',
-                    'path' => 'C:\path\file.ext',
-                    'port' => null,
-                    'user' => null,
-                    'query' => null,
-                    'fragment' => null,
-                ],
-            ],
-            [
-                'file:///C:',
-                [
-                    'scheme' => 'file',
-                    'host' => '',
-                    'path' => 'C:',
                     'port' => null,
                     'user' => null,
                     'query' => null,

--- a/tests/Uri/ResolveTest.php
+++ b/tests/Uri/ResolveTest.php
@@ -129,6 +129,11 @@ class ResolveTest extends TestCase
                 'file_b.ext',
                 'file:///C:/path/file_b.ext',
             ],
+            [
+                'file:///C:/path/of/dirs/',
+                'file.txt',
+                'file:///C:/path/of/dirs/file.txt',
+            ],
         ];
     }
 }


### PR DESCRIPTION
1) add an explicit unit test for issue #31 
2) Adjust README to mention Windows-style paths
3) Add empty host and leading slash to Windows file paths (this is a remake of PR #71
4) changelog and version bump to 3.0.0
