### PR TITLE
Revert 71 and adjust test scenarios

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -203,19 +203,6 @@ function parse(string $uri): array
     $result = parse_url($uri);
     if (!$result) {
         $result = _parse_fallback($uri);
-    } else {
-        // Add empty host and trailing slash to Windows file paths
-        // file:///C:/path or file:///C:\path
-        // Note: the regex fragment [a-zA-Z]:[\/\\\\].* end up being
-        // [a-zA-Z]:[\/\\].*
-        // The 4 backslash in a row are the way to get 2 backslash into the actual string
-        // that is used as the regex. The 2 backslash are then the way to get 1 backslash
-        // character into the character set "a forward slash or a backslash"
-        if (isset($result['scheme']) && 'file' === $result['scheme'] && isset($result['path']) &&
-             preg_match('/^(?<windows_path> [a-zA-Z]:([\/\\\\].*)?)$/x', $result['path'])) {
-            $result['path'] = '/'.$result['path'];
-            $result['host'] = '';
-        }
     }
 
     /*

--- a/tests/Uri/ParseTest.php
+++ b/tests/Uri/ParseTest.php
@@ -10,6 +10,7 @@ class ParseTest extends TestCase
 {
     /**
      * @dataProvider parseData
+     * @dataProvider windowsFormatTestCasesForParse
      *
      * @param array<int, array<int, array<string, int|string|null>|string>> $out
      */
@@ -23,6 +24,7 @@ class ParseTest extends TestCase
 
     /**
      * @dataProvider parseData
+     * @dataProvider windowsFormatTestCasesForParseFallback
      *
      * @param array<int, array<int, array<string, int|string|null>|string>> $out
      */
@@ -225,7 +227,15 @@ class ParseTest extends TestCase
                     'fragment' => null,
                 ],
             ],
-            // Windows Paths
+        ];
+    }
+
+    /**
+     * @return array<int, array<int, array<string, int|string|null>|string>>
+     */
+    public function windowsFormatTestCasesForParseFallback(): array
+    {
+        return [
             [
                 'file:///C:/path/file.ext',
                 [
@@ -256,6 +266,58 @@ class ParseTest extends TestCase
                     'scheme' => 'file',
                     'host' => '',
                     'path' => '/C:',
+                    'port' => null,
+                    'user' => null,
+                    'query' => null,
+                    'fragment' => null,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * These test cases demonstrate that the parse() function does not
+     * return a "/" at the start of the path for URIs of the form
+     * file:///C:/something...
+     *
+     * See issue comment https://github.com/sabre-io/uri/pull/71#issuecomment-1250724859
+     * and gthe linked issues and PRs.
+     *
+     * @return array<int, array<int, array<string, int|string|null>|string>>
+     */
+    public function windowsFormatTestCasesForParse(): array
+    {
+        return [
+            [
+                'file:///C:/path/file.ext',
+                [
+                    'scheme' => 'file',
+                    'host' => '',
+                    'path' => 'C:/path/file.ext',
+                    'port' => null,
+                    'user' => null,
+                    'query' => null,
+                    'fragment' => null,
+                ],
+            ],
+            [
+                'file:///C:\path\file.ext',
+                [
+                    'scheme' => 'file',
+                    'host' => '',
+                    'path' => 'C:\path\file.ext',
+                    'port' => null,
+                    'user' => null,
+                    'query' => null,
+                    'fragment' => null,
+                ],
+            ],
+            [
+                'file:///C:',
+                [
+                    'scheme' => 'file',
+                    'host' => '',
+                    'path' => 'C:',
                     'port' => null,
                     'user' => null,
                     'query' => null,


### PR DESCRIPTION
- revert the functional code changes from #71 that are causing the issue described in #81 
- adjust the unit test scenarios, they now demonstrate the differences between the built-in PHP parse and the parse fallabck.

After merging this, I can make a patch release to put the behavior back.

Then I can apply the fix again, and do a major version release.