### PR TITLE
Prepare 2.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ ChangeLog
 
 * #74: Minimum PHP 7.4 - drops PHP 7.1 7.2 and 7.3 and adds more type declarations (@phil-davis)
 
+2.2.4 (2022-09-19)
+------------------
+
+* #83: Revert windows file paths change (was PR 71). See issue 81 (@phil-davis)
+
 2.2.3 (2022-08-17)
 ------------------
 


### PR DESCRIPTION
Insert the changelog for 2.2.4.

I released that in branch `release-2.2.4` that was branched from the 2.2.3 tag. That is a stand-alone release to make the reverted code from PR #83 available to consumers of the 2.2.* release series.

This PR just gets the changelog into master. No code changes are needed in master - those were already done in PR #83 on master branch and released in 2.3.2