### PR TITLE
Add phpstan-phpunit phpstan-strict-rules to phpstan analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,9 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.14",
         "phpstan/phpstan": "^1.9",
+        "phpstan/phpstan-phpunit": "^1.3",
+        "phpstan/phpstan-strict-rules": "^1.4",
+        "phpstan/extension-installer": "^1.2",
         "phpunit/phpunit" : "^9.6"
     },
     "scripts": {
@@ -56,5 +59,10 @@
             "composer cs-fixer",
             "composer phpunit"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
     }
 }

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -26,15 +26,15 @@ function resolve(string $basePath, string $newPath): string
 
     // If the new path defines a scheme, it's absolute and we can just return
     // that.
-    if ($delta['scheme']) {
+    if (null !== $delta['scheme']) {
         return build($delta);
     }
 
     $base = parse($basePath);
     $pick = function ($part) use ($base, $delta) {
-        if ($delta[$part]) {
+        if (null !== $delta[$part]) {
             return $delta[$part];
-        } elseif ($base[$part]) {
+        } elseif (null !== $base[$part]) {
             return $base[$part];
         }
 
@@ -85,13 +85,13 @@ function resolve(string $basePath, string $newPath): string
 
     // If the source url ended with a /, we want to preserve that.
     $newParts['path'] = 0 === strpos($path, '/') ? $path : '/'.$path;
-    if ($delta['query']) {
+    if (null !== $delta['query']) {
         $newParts['query'] = $delta['query'];
     } elseif (!empty($base['query']) && empty($delta['host']) && empty($delta['path'])) {
         // Keep the old query if host and path didn't change
         $newParts['query'] = $base['query'];
     }
-    if ($delta['fragment']) {
+    if (null !== $delta['fragment']) {
         $newParts['fragment'] = $delta['fragment'];
     }
 
@@ -134,7 +134,7 @@ function normalize(string $uri): string
         $parts['path'] = '/'.implode('/', $newPathParts);
     }
 
-    if ($parts['scheme']) {
+    if (null !== $parts['scheme']) {
         $parts['scheme'] = strtolower($parts['scheme']);
         $defaultPorts = [
             'http' => '80',
@@ -157,7 +157,7 @@ function normalize(string $uri): string
         }
     }
 
-    if ($parts['host']) {
+    if (null !== $parts['host']) {
         $parts['host'] = strtolower($parts['host']);
     }
 
@@ -201,7 +201,7 @@ function parse(string $uri): array
     }
 
     $result = parse_url($uri);
-    if (!$result) {
+    if (false === $result) {
         $result = _parse_fallback($uri);
     } else {
         // Add empty host and leading slash to Windows file paths
@@ -212,7 +212,7 @@ function parse(string $uri): array
         // that is used as the regex. The 2 backslash are then the way to get 1 backslash
         // character into the character set "a forward slash or a backslash"
         if (isset($result['scheme']) && 'file' === $result['scheme'] && isset($result['path']) &&
-            preg_match('/^(?<windows_path> [a-zA-Z]:([\/\\\\].*)?)$/x', $result['path'])) {
+            1 === preg_match('/^(?<windows_path> [a-zA-Z]:([\/\\\\].*)?)$/x', $result['path'])) {
             $result['path'] = '/'.$result['path'];
             $result['host'] = '';
         }
@@ -265,7 +265,7 @@ function build(array $parts): string
         // If there's a scheme, there's also a host.
         $uri = $parts['scheme'].':';
     }
-    if ($authority || (!empty($parts['scheme']) && 'file' === $parts['scheme'])) {
+    if ('' !== $authority || (!empty($parts['scheme']) && 'file' === $parts['scheme'])) {
         // No scheme, but there is a host.
         $uri .= '//'.$authority;
     }
@@ -303,7 +303,7 @@ function build(array $parts): string
 function split(string $path): array
 {
     $matches = [];
-    if (preg_match('/^(?:(?:(.*)(?:\/+))?([^\/]+))(?:\/?)$/u', $path, $matches)) {
+    if (1 === preg_match('/^(?:(?:(.*)(?:\/+))?([^\/]+))(?:\/?)$/u', $path, $matches)) {
         return [$matches[1], $matches[2]];
     }
 
@@ -353,7 +353,7 @@ function _parse_fallback(string $uri): array
         'query' => null,
     ];
 
-    if (preg_match('% ^([A-Za-z][A-Za-z0-9+-\.]+): %x', $uri, $matches)) {
+    if (1 === preg_match('% ^([A-Za-z][A-Za-z0-9+-\.]+): %x', $uri, $matches)) {
         $result['scheme'] = $matches[1];
         // Take what's left.
         $uri = substr($uri, strlen($result['scheme']) + 1);
@@ -382,10 +382,10 @@ function _parse_fallback(string $uri): array
             (?: : (?<port> [0-9]+))?
             (?<path> / .*)?
           $%x';
-        if (!preg_match($regex, $uri, $matches)) {
+        if (1 !== preg_match($regex, $uri, $matches)) {
             throw new InvalidUriException('Invalid, or could not parse URI');
         }
-        if ($matches['host']) {
+        if (isset($matches['host']) && '' !== $matches['host']) {
             $result['host'] = $matches['host'];
         }
         if (isset($matches['port'])) {
@@ -394,10 +394,10 @@ function _parse_fallback(string $uri): array
         if (isset($matches['path'])) {
             $result['path'] = $matches['path'];
         }
-        if ($matches['user']) {
+        if (isset($matches['user']) && '' !== $matches['user']) {
             $result['user'] = $matches['user'];
         }
-        if ($matches['pass']) {
+        if (isset($matches['pass']) && '' !== $matches['pass']) {
             $result['pass'] = $matches['pass'];
         }
     } else {

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -116,7 +116,7 @@ function normalize(string $uri): string
 {
     $parts = parse($uri);
 
-    if (!empty($parts['path'])) {
+    if (isset($parts['path'])) {
         $pathParts = explode('/', ltrim($parts['path'], '/'));
         $newPathParts = [];
         foreach ($pathParts as $pathPart) {
@@ -144,7 +144,7 @@ function normalize(string $uri): string
             'https' => '443',
         ];
 
-        if (!empty($parts['port']) && isset($defaultPorts[$parts['scheme']]) && $defaultPorts[$parts['scheme']] == $parts['port']) {
+        if (isset($parts['port']) && isset($defaultPorts[$parts['scheme']]) && $defaultPorts[$parts['scheme']] == $parts['port']) {
             // Removing default ports.
             unset($parts['port']);
         }
@@ -152,7 +152,7 @@ function normalize(string $uri): string
         switch ($parts['scheme']) {
             case 'http':
             case 'https':
-                if (empty($parts['path'])) {
+                if (!isset($parts['path'])) {
                     // An empty path is equivalent to / in http.
                     $parts['path'] = '/';
                 }

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -91,7 +91,7 @@ function resolve(string $basePath, string $newPath): string
     // An empty query "http://example.com/foo?" causes 'query' to be the empty string
     if (null !== $delta['query'] && '' !== $delta['query']) {
         $newParts['query'] = $delta['query'];
-    } elseif (isset($base['query']) && null !== $delta['host'] && null !== $delta['path']) {
+    } elseif (isset($base['query']) && null === $delta['host'] && null === $delta['path']) {
         // Keep the old query if host and path didn't change
         $newParts['query'] = $base['query'];
     }

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -381,14 +381,11 @@ function _parse_fallback(string $uri): array
     if ('///' === substr($uri, 0, 3)) {
         // The triple slash uris are a bit unusual, but we have special handling
         // for them.
-        /**
-         * We know that this is a string, because the first 3 characters are '///'.
-         * So we can always do a sub-string starting from offset 2 (the 3rd '/').
-         *
-         * @var string $x
-         */
-        $x = substr($uri, 2);
-        $result['path'] = $x;
+        $path = substr($uri, 2);
+        if (false === $path) {
+            throw new \RuntimeException('The string cannot be false');
+        }
+        $result['path'] = $path;
         $result['host'] = '';
     } elseif ('//' === substr($uri, 0, 2)) {
         // Uris that have an authority part.

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -88,13 +88,17 @@ function resolve(string $basePath, string $newPath): string
 
     // If the source url ended with a /, we want to preserve that.
     $newParts['path'] = 0 === strpos($path, '/') ? $path : '/'.$path;
-    if (null !== $delta['query']) {
+    // From PHP 8, no "?" query at all causes 'query' to be null.
+    // An empty query "http://example.com/foo?" causes 'query' to be the empty string
+    if (null !== $delta['query'] && '' !== $delta['query']) {
         $newParts['query'] = $delta['query'];
     } elseif (isset($base['query']) && !isset($delta['host']) && !isset($delta['path'])) {
         // Keep the old query if host and path didn't change
         $newParts['query'] = $base['query'];
     }
-    if (null !== $delta['fragment']) {
+    // From PHP 8, no "#" fragment at all causes 'fragment' to be null.
+    // An empty fragment "http://example.com/foo#" causes 'fragment' to be the empty string
+    if (null !== $delta['fragment'] && '' !== $delta['fragment']) {
         $newParts['fragment'] = $delta['fragment'];
     }
 

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -90,7 +90,7 @@ function resolve(string $basePath, string $newPath): string
     $newParts['path'] = 0 === strpos($path, '/') ? $path : '/'.$path;
     if (null !== $delta['query']) {
         $newParts['query'] = $delta['query'];
-    } elseif (!empty($base['query']) && empty($delta['host']) && empty($delta['path'])) {
+    } elseif (isset($base['query']) && !isset($delta['host']) && !isset($delta['path'])) {
         // Keep the old query if host and path didn't change
         $newParts['query'] = $base['query'];
     }

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -254,32 +254,32 @@ function build(array $parts): string
     $uri = '';
 
     $authority = '';
-    if (!empty($parts['host'])) {
+    if (isset($parts['host'])) {
         $authority = $parts['host'];
-        if (!empty($parts['user'])) {
+        if (isset($parts['user'])) {
             $authority = $parts['user'].'@'.$authority;
         }
-        if (!empty($parts['port'])) {
+        if (isset($parts['port'])) {
             $authority = $authority.':'.$parts['port'];
         }
     }
 
-    if (!empty($parts['scheme'])) {
+    if (isset($parts['scheme'])) {
         // If there's a scheme, there's also a host.
         $uri = $parts['scheme'].':';
     }
-    if ('' !== $authority || (!empty($parts['scheme']) && 'file' === $parts['scheme'])) {
+    if ('' !== $authority || (isset($parts['scheme']) && 'file' === $parts['scheme'])) {
         // No scheme, but there is a host.
         $uri .= '//'.$authority;
     }
 
-    if (!empty($parts['path'])) {
+    if (isset($parts['path'])) {
         $uri .= $parts['path'];
     }
-    if (!empty($parts['query'])) {
+    if (isset($parts['query'])) {
         $uri .= '?'.$parts['query'];
     }
-    if (!empty($parts['fragment'])) {
+    if (isset($parts['fragment'])) {
         $uri .= '#'.$parts['fragment'];
     }
 

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -62,7 +62,10 @@ function resolve(string $basePath, string $newPath): string
             $path .= '/'.$delta['path'];
         }
     } else {
-        $path = $base['path'] ?: '/';
+        $path = $base['path'] ?? '/';
+        if ('' === $path) {
+            $path = '/';
+        }
     }
     // Removing .. and .
     $pathParts = explode('/', $path);

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -257,12 +257,12 @@ function build(array $parts): string
     $uri = '';
 
     $authority = '';
-    if (null !== $parts['host']) {
+    if (isset($parts['host'])) {
         $authority = $parts['host'];
-        if (null !== $parts['user']) {
+        if (isset($parts['user'])) {
             $authority = $parts['user'].'@'.$authority;
         }
-        if (null !== $parts['port']) {
+        if (isset($parts['port'])) {
             $authority = $authority.':'.$parts['port'];
         }
     }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,6 @@
 parameters:
   level: 9
+  ignoreErrors:
+  -
+    message: "#^.* will always evaluate to true\\.$#"
+    path: tests/*

--- a/tests/Uri/BuildTest.php
+++ b/tests/Uri/BuildTest.php
@@ -32,15 +32,19 @@ class BuildTest extends TestCase
             ['http://example.org/foo/bar'],
             ['//example.org/foo/bar'],
             ['/foo/bar'],
+            ['0'],
             ['http://example.org:81/'],
             ['http://user@example.org:81/'],
+            ['http://0@example.org:81/'],
             ['http://example.org:81/hi?a=b'],
             ['http://example.org:81/hi?a=b#c=d'],
             // [ '//example.org:81/hi?a=b#c=d'], // Currently fails due to a
             // PHP bug.
             ['/hi?a=b#c=d'],
             ['?a=b#c=d'],
+            ['?0'],
             ['#c=d'],
+            ['#0'],
             ['file:///etc/hosts'],
             ['file://localhost/etc/hosts'],
         ];

--- a/tests/Uri/NormalizeTest.php
+++ b/tests/Uri/NormalizeTest.php
@@ -32,6 +32,7 @@ class NormalizeTest extends TestCase
             ['http://example.org/./evert',      'http://example.org/evert'],
             ['http://example.org/../evert',     'http://example.org/evert'],
             ['http://example.org/foo/../evert', 'http://example.org/evert'],
+            ['http://example.org/0',            'http://example.org/0'],
             ['/%41',                            '/A'],
             ['/%3F',                            '/%3F'],
             ['/%3f',                            '/%3F'],

--- a/tests/Uri/ResolveTest.php
+++ b/tests/Uri/ResolveTest.php
@@ -116,12 +116,6 @@ class ResolveTest extends TestCase
                 '#foo',
                 'http://www.example.org/#foo',
             ],
-            // Another fragment test
-            [
-                'http://example.org/path.json',
-                '#',
-                'http://example.org/path.json',
-            ],
             // Allow to use 0 in path
             [
                 'http://example.org/',

--- a/tests/Uri/ResolveTest.php
+++ b/tests/Uri/ResolveTest.php
@@ -123,6 +123,49 @@ class ResolveTest extends TestCase
                 '0',
                 'http://example.org/0',
             ],
+            // Allow to use 0 in base path
+            [
+                'http://example.org/0',
+                '//example.net',
+                'http://example.net/0',
+            ],
+            [
+                'http://example.org/0',
+                '//example.net/',
+                'http://example.net/',
+            ],
+            // Allow to use a base with only the path
+            [
+                '0',
+                '//example.net',
+                '//example.net/0',
+            ],
+            [
+                'a',
+                '//example.net',
+                '//example.net/a',
+            ],
+            [
+                '0',
+                '//example.net/',
+                '//example.net/',
+            ],
+            [
+                'a',
+                '//example.net/',
+                '//example.net/',
+            ],
+            // Allow to use an empty base
+            [
+                '',
+                '//example.net',
+                '//example.net/',
+            ],
+            [
+                '',
+                '//example.net/',
+                '//example.net/',
+            ],
             // Windows Paths
             [
                 'file:///C:/path/file_a.ext',

--- a/tests/Uri/ResolveTest.php
+++ b/tests/Uri/ResolveTest.php
@@ -83,6 +83,11 @@ class ResolveTest extends TestCase
                 '#comments',
                 'https://example.org/foo?a=b#comments',
             ],
+            [
+                'https://example.org/foo?0',
+                '#comments',
+                'https://example.org/foo?0#comments',
+            ],
             // Switching to mailto!
             [
                 'https://example.org/foo?a=b',


### PR DESCRIPTION
see my comments - fixes a few edge-cases when a URI component might be the string "0" (path, username, query, fragment...). These are not really common in everyday use!

Gets the strict phpstan rules passing.