### PR TITLE
Minor cs-fixer change and add count to phpstan.neon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,11 +37,11 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.14",
-        "phpstan/phpstan": "^1.9",
+        "friendsofphp/php-cs-fixer": "^3.17",
+        "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
-        "phpstan/phpstan-strict-rules": "^1.4",
-        "phpstan/extension-installer": "^1.2",
+        "phpstan/phpstan-strict-rules": "^1.5",
+        "phpstan/extension-installer": "^1.3",
         "phpunit/phpunit" : "^9.6"
     },
     "scripts": {

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -217,8 +217,8 @@ function parse(string $uri): array
         // The 4 backslash in a row are the way to get 2 backslash into the actual string
         // that is used as the regex. The 2 backslash are then the way to get 1 backslash
         // character into the character set "a forward slash or a backslash"
-        if (isset($result['scheme']) && 'file' === $result['scheme'] && isset($result['path']) &&
-            1 === preg_match('/^(?<windows_path> [a-zA-Z]:([\/\\\\].*)?)$/x', $result['path'])) {
+        if (isset($result['scheme']) && 'file' === $result['scheme'] && isset($result['path'])
+            && 1 === preg_match('/^(?<windows_path> [a-zA-Z]:([\/\\\\].*)?)$/x', $result['path'])) {
             $result['path'] = '/'.$result['path'];
             $result['host'] = '';
         }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,3 +4,4 @@ parameters:
   -
     message: "#^.* will always evaluate to true\\.$#"
     path: tests/*
+    count: 1


### PR DESCRIPTION
I some recent cs-fixer release it seems that it wants and/or `&&` `||` to be at the start of continuation lines of complex logic conditions. This little change fixes `composer cs-fixer`.

I updated all the `require-dev` dependencies to show what minor version they are currently at, because that is what is really used in CI and what we know passes.

Added `count` in `phpstan.neon` `ignoreErrors`. That is a bit of extra validation, in case someone accidentally adds more code that happens to have the same problem - the CI will fail because `count` will b `2` and so the person will know and will have to think about it.