### PR TITLE
Prepare 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 ChangeLog
 =========
 
+3.0.1 (2023-06-09)
+------------------
+
+* #89: Call static assert functions with self:: (tests only) (@phil-davis)
+* #90: Implement phpstan strict rules and fix edge cases for paths that have "0" (@phil-davis)
+* #91: Use newer GitHub workflow action versions (CI only) (@phil-davis)
+* #93: Minor cs-fixer change (@phil-davis)
+
 3.0.0 (2022-09-26)
 ------------------
 

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    public const VERSION = '3.0.0';
+    public const VERSION = '3.0.1';
 }


### PR DESCRIPTION
The phpstan strict rules resulted in quite a few code changes, specially in `if` tests. And some edge-cases were fixed, specially in some cases where a URL might have a string character zero "0" in a path. I guess not many people come across these edge cases, because it is unusual to have something like `http://mysite.com/0/some/path` 

Anyway, I think that the changes are all bug-fixes and refactoring, so this can be a patch release 3.0.1.