### PR TITLE
Prepare release 2.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 ChangeLog
 =========
 
+2.3.3 (2023-06-09)
+------------------
+
+* #89: Call static assert functions with self:: (tests only) (@phil-davis)
+* #90: Implement phpstan strict rules and fix edge cases for paths that have "0" (@phil-davis)
+* #91: Use newer GitHub workflow action versions (CI only) (@phil-davis)
+* #93: Minor cs-fixer change (@phil-davis)
+
 2.3.2 (2022-09-19)
 ------------------
 

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    public const VERSION = '2.3.2';
+    public const VERSION = '2.3.3';
 }


### PR DESCRIPTION
to release a patch for the v2 release series.

I can still easily release the recent fixes/changes that I backported to the `v2` branch in PR #95 