### PR TITLE
Update CI and test things

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.17",
+        "friendsofphp/php-cs-fixer": "^3.38",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-strict-rules": "^1.5",

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,4 +1,6 @@
+<?xml version="1.0"?>
 <phpunit
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   colors="true"
   bootstrap="../vendor/autoload.php"
   convertErrorsToExceptions="true"
@@ -6,16 +8,16 @@
   convertWarningsToExceptions="true"
   beStrictAboutTestsThatDoNotTestAnything="true"
   beStrictAboutOutputDuringTests="true"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
   >
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">../lib/</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="sabre-uri">
       <directory>.</directory>
     </testsuite>
   </testsuites>
-
-  <filter>
-    <whitelist addUncoveredFilesFromWhitelist="true">
-        <directory suffix=".php">../lib/</directory>
-   </whitelist>
-  </filter>
 </phpunit>


### PR DESCRIPTION
1) `phpunit` reports:
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

Done with:
```
./vendor/phpunit/phpunit/phpunit  --configuration tests/phpunit.xml --migrate-configuration
```

2) Update the php-cs-fixer minor version to the current one. That is what runs today and passes. It is sometimes handy to know what is the latest that was passing.
