### PR TITLE
Change array<int...> to list<...> in PHP doc

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -304,7 +304,7 @@ function build(array $parts): string
  * If there is no dirname, it will return an empty string. Any / appearing at
  * the end of the string is stripped off.
  *
- * @return array<int, mixed>
+ * @return list<mixed>
  */
 function split(string $path): array
 {

--- a/tests/Uri/BuildTest.php
+++ b/tests/Uri/BuildTest.php
@@ -23,7 +23,7 @@ class BuildTest extends TestCase
     }
 
     /**
-     * @return array<int, array<int, string>>
+     * @return list<list<string>>
      */
     public function buildUriData(): array
     {

--- a/tests/Uri/NormalizeTest.php
+++ b/tests/Uri/NormalizeTest.php
@@ -20,7 +20,7 @@ class NormalizeTest extends TestCase
     }
 
     /**
-     * @return array<int, array<int, string>>
+     * @return list<list<string>>
      */
     public function normalizeData(): array
     {

--- a/tests/Uri/ParseTest.php
+++ b/tests/Uri/ParseTest.php
@@ -12,7 +12,7 @@ class ParseTest extends TestCase
      * @dataProvider parseData
      * @dataProvider windowsFormatTestCases
      *
-     * @param array<int, array<int, array<string, int|string|null>|string>> $out
+     * @param list<list<array<string, int|string|null>|string>> $out
      */
     public function testParse(string $in, array $out): void
     {
@@ -26,7 +26,7 @@ class ParseTest extends TestCase
      * @dataProvider parseData
      * @dataProvider windowsFormatTestCases
      *
-     * @param array<int, array<int, array<string, int|string|null>|string>> $out
+     * @param list<list<array<string, int|string|null>|string>> $out
      */
     public function testParseFallback(string $in, array $out): void
     {
@@ -56,7 +56,7 @@ class ParseTest extends TestCase
     }
 
     /**
-     * @return array<int, array<int, array<string, int|string|null>|string>>
+     * @return list<list<array<string, int|string|null>|string>>
      */
     public function parseData(): array
     {
@@ -231,7 +231,7 @@ class ParseTest extends TestCase
     }
 
     /**
-     * @return array<int, array<int, array<string, int|string|null>|string>>
+     * @return list<list<array<string, int|string|null>|string>>
      */
     public function windowsFormatTestCases(): array
     {

--- a/tests/Uri/ResolveTest.php
+++ b/tests/Uri/ResolveTest.php
@@ -22,7 +22,7 @@ class ResolveTest extends TestCase
     }
 
     /**
-     * @return array<int, array<int, string>>
+     * @return list<list<string>>
      */
     public function resolveData(): array
     {


### PR DESCRIPTION
I found this PR again today (2024-04-18!).
It looks like I did something reasonable, but, TBH, I don't remember what caused me to start doing this sort of minor refactoring of the PHPdoc.

Maybe we did this already in other sabre repos? I would have to search around to find it.