### PR TITLE
chore: use php-cs-fixer 3.51

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.49",
+        "friendsofphp/php-cs-fixer": "^3.51",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-strict-rules": "^1.5",


### PR DESCRIPTION
Just keeping this recording the same 3.51 version of cs-fixer as is recorded in the other repos.