### PR TITLE
chore: bump php-cs-fixer to 3.54 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.51",
+        "friendsofphp/php-cs-fixer": "^3.54",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-strict-rules": "^1.5",


### PR DESCRIPTION
I forgot to do this earlier today.
It is nice to have the php-cs-fixer version that is currently known to pass, to be mentioned in composer.json
because that is the minimum version that someone has to use locally when doing 
`composer cs-fixer`