### PR TITLE
Add PHP 8.4 to CI for v2 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,16 @@ jobs:
       matrix:
         php-versions: ['8.0', '8.1', '8.2', '8.3']
         coverage: ['pcov']
+        code-style: ['no']
         code-analysis: ['no']
         include:
           - php-versions: '7.4'
             coverage: 'none'
+            code-style: 'yes'
+            code-analysis: 'yes'
+          - php-versions: '8.4'
+            coverage: 'none'
+            code-style: 'no'
             code-analysis: 'yes'
     steps:
       - name: Checkout
@@ -48,8 +54,8 @@ jobs:
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Code Analysis (PHP CS-Fixer)
-        if: matrix.code-analysis == 'yes'
-        run: php vendor/bin/php-cs-fixer fix --dry-run --diff
+        if: matrix.code-style == 'yes'
+        run: PHP_CS_FIXER_IGNORE_ENV=true php vendor/bin/php-cs-fixer fix --dry-run --diff
 
       - name: Code Analysis (PHPStan)
         if: matrix.code-analysis == 'yes'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
   level: 9
+  reportUnmatchedIgnoredErrors: false
   ignoreErrors:
   -
     message: "#^.* will always evaluate to true\\.$#"


### PR DESCRIPTION
Related issue https://github.com/sabre-io/event/issues/123

Only CI and dev tooling changes are needed. Passes for PHP 8.4.
There is no source code to change. So no need to do a patch release to support PHP 8.4.