### PR TITLE
chore: check for nullable_type_declaration

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -7,7 +7,11 @@ $finder = PhpCsFixer\Finder::create()
 $config = new PhpCsFixer\Config();
 $config->setRules([
     '@PSR1' => true,
-    '@Symfony' => true
+    '@Symfony' => true,
+    'nullable_type_declaration' => [
+        'syntax' => 'question_mark',
+    ],
+    'nullable_type_declaration_for_default_null_value' => true,
 ]);
 $config->setFinder($finder);
 return $config;


### PR DESCRIPTION
As suggested by @cedric-anne in https://github.com/sabre-io/dav/pull/1556#issuecomment-2255112506

I manually added an `= null` locally to a function parameter, and ran cs-fixer. It correctly reported the problem and added the fix - putting the `?` in front of the type declaration. So cs-fixer running on PHP 7.4 will find and fix this issue that causes deprecation warnings on PHP 8.4.