### PR TITLE
chore: update CI for PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,16 @@ jobs:
       matrix:
         php-versions: ['8.0', '8.1', '8.2', '8.3']
         coverage: ['pcov']
+        code-style: ['no']
         code-analysis: ['no']
         include:
           - php-versions: '7.4'
             coverage: 'none'
+            code-style: 'yes'
+            code-analysis: 'yes'
+          - php-versions: '8.4'
+            coverage: 'none'
+            code-style: 'no'
             code-analysis: 'yes'
     steps:
       - name: Checkout
@@ -48,8 +54,8 @@ jobs:
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Code Analysis (PHP CS-Fixer)
-        if: matrix.code-analysis == 'yes'
-        run: php vendor/bin/php-cs-fixer fix --dry-run --diff
+        if: matrix.code-style == 'yes'
+        run: PHP_CS_FIXER_IGNORE_ENV=true php vendor/bin/php-cs-fixer fix --dry-run --diff
 
       - name: Code Analysis (PHPStan)
         if: matrix.code-analysis == 'yes'

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -7,7 +7,11 @@ $finder = PhpCsFixer\Finder::create()
 $config = new PhpCsFixer\Config();
 $config->setRules([
     '@PSR1' => true,
-    '@Symfony' => true
+    '@Symfony' => true,
+    'nullable_type_declaration' => [
+        'syntax' => 'question_mark',
+    ],
+    'nullable_type_declaration_for_default_null_value' => true,
 ]);
 $config->setFinder($finder);
 return $config;

--- a/composer.json
+++ b/composer.json
@@ -37,11 +37,11 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.56",
-        "phpstan/phpstan": "^1.11",
+        "friendsofphp/php-cs-fixer": "^3.64",
+        "phpstan/phpstan": "^1.12",
         "phpstan/phpstan-phpunit": "^1.4",
         "phpstan/phpstan-strict-rules": "^1.6",
-        "phpstan/extension-installer": "^1.3",
+        "phpstan/extension-installer": "^1.4",
         "phpunit/phpunit" : "^9.6"
     },
     "scripts": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
   level: 9
+  reportUnmatchedIgnoredErrors: false
   ignoreErrors:
   -
     message: "#^.* will always evaluate to true\\.$#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,3 +5,19 @@ parameters:
     message: "#^.* will always evaluate to true\\.$#"
     path: tests/*
     count: 1
+  -
+    message: "#^Offset .* in isset\\(\\) always exists and is not nullable\\.$#"
+    path: lib/functions.php
+    count: 3
+  -
+    message: "#^Result of && is always true\\.$#"
+    path: lib/functions.php
+    count: 1
+  -
+    message: "#^Strict comparison using !== between '' and non-falsy-string will always evaluate to true\\.$#"
+    path: lib/functions.php
+    count: 1
+  -
+    message: "#^Strict comparison using === between false and string will always evaluate to false\\.$#"
+    path: lib/functions.php
+    count: 2


### PR DESCRIPTION
Similar to what was done for the v2 branch for release https://github.com/sabre-io/uri/releases/tag/2.3.4
Code from #116 and #117 
And adjust phpstan config like in #120 
For now, I am ignoring phpstan "errors" like: `* will always evaluate to true` 
because it is telling that the code is overly cautious, and I will leave the overly-cautious code as it does no harm.

This now confirms in CI that everything is passing for PHP 8.4 in the master branch.

There are no actual code changes, so I will look to see what else has happened in the master branch since the latest 3.0.1 release. If there are code changes waiting, then I will make release 3.0.2
