### PR TITLE
chore(deps): update phpunit from 9 to 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/extension-installer": "^1.4",
-        "phpunit/phpunit" : "^9.6"
+        "phpunit/phpunit" : "^10"
     },
     "scripts": {
         "phpstan": [

--- a/tests/Uri/BuildTest.php
+++ b/tests/Uri/BuildTest.php
@@ -25,7 +25,7 @@ class BuildTest extends TestCase
     /**
      * @return list<list<string>>
      */
-    public function buildUriData(): array
+    public static function buildUriData(): array
     {
         return [
             ['http://example.org/'],

--- a/tests/Uri/NormalizeTest.php
+++ b/tests/Uri/NormalizeTest.php
@@ -22,7 +22,7 @@ class NormalizeTest extends TestCase
     /**
      * @return list<list<string>>
      */
-    public function normalizeData(): array
+    public static function normalizeData(): array
     {
         return [
             ['https://example.org/',            'https://example.org/'],

--- a/tests/Uri/ParseTest.php
+++ b/tests/Uri/ParseTest.php
@@ -58,7 +58,7 @@ class ParseTest extends TestCase
     /**
      * @return list<list<array<string, int|string|null>|string>>
      */
-    public function parseData(): array
+    public static function parseData(): array
     {
         return [
             [
@@ -233,7 +233,7 @@ class ParseTest extends TestCase
     /**
      * @return list<list<array<string, int|string|null>|string>>
      */
-    public function windowsFormatTestCases(): array
+    public static function windowsFormatTestCases(): array
     {
         return [
             [

--- a/tests/Uri/ResolveTest.php
+++ b/tests/Uri/ResolveTest.php
@@ -24,7 +24,7 @@ class ResolveTest extends TestCase
     /**
      * @return list<list<string>>
      */
-    public function resolveData(): array
+    public static function resolveData(): array
     {
         return [
             [

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,24 +1,19 @@
 <?xml version="1.0"?>
-<phpunit
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  colors="true"
-  bootstrap="../vendor/autoload.php"
-  convertErrorsToExceptions="true"
-  convertNoticesToExceptions="true"
-  convertWarningsToExceptions="true"
-  convertDeprecationsToExceptions="true"
-  beStrictAboutTestsThatDoNotTestAnything="true"
-  beStrictAboutOutputDuringTests="true"
-  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-  >
-  <coverage includeUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">../lib/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         colors="true"
+         bootstrap="../vendor/autoload.php"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="sabre-uri">
       <directory>.</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">../lib/</directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
* Update phpunit
* Migrate config with phpunit
* Apply phpunit10 set (rector setup borrowed from https://github.com/sabre-io/uri/pull/133)

@phil-davis I'm a bit unsure if such change has to happen for all sabre packages at once to avoid any conflicts when linking the packages locally. If so I can also tackle the others. This one seemed to be the easiest to migrate.