### PR TITLE
chore: prepare release 3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ChangeLog
 =========
 
+3.0.3 (2026-04-01)
+------------------
+
+* #124 phpstan major version 2 (@phil-davis)
+* #127 add PHP 8.5 to CI workflows (@phil-davis)
+* #133 refactor: add and apply rector (ChristophWurst)
+
 3.0.2 (2024-09-04)
 ------------------
 

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    public const VERSION = '3.0.2';
+    public const VERSION = '3.0.3';
 }


### PR DESCRIPTION
This releases the current code, which has a few minor refactorings suggested by phpstan and rector. See the PRs linked in the release notes.

Without or without this release, URI works with PHP 7.4 through 8.5.

This is likely the last release that supports PHP 7.4.