### PR TITLE
chore: add rector check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,12 @@ jobs:
             coverage: 'none'
             code-style: 'yes'
             code-analysis: 'yes'
-            rector-check: 'yes'
+            rector-check: 'no'
           - php-versions: '8.5'
             coverage: 'none'
             code-style: 'no'
             code-analysis: 'yes'
-            rector-check: 'no'
+            rector-check: 'yes'
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,18 @@ jobs:
         coverage: ['pcov']
         code-style: ['no']
         code-analysis: ['no']
+        rector-check: ['no']
         include:
           - php-versions: '7.4'
             coverage: 'none'
             code-style: 'yes'
             code-analysis: 'yes'
+            rector-check: 'yes'
           - php-versions: '8.5'
             coverage: 'none'
             code-style: 'no'
             code-analysis: 'yes'
+            rector-check: 'no'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -60,6 +63,10 @@ jobs:
       - name: Code Analysis (PHPStan)
         if: matrix.code-analysis == 'yes'
         run: composer phpstan
+
+      - name: Code Refactoring (rector)
+        if: matrix.rector-check == 'yes'
+        run: composer rector-check
 
       - name: Test with phpunit
         run: vendor/bin/phpunit --configuration tests/phpunit.xml --coverage-clover clover.xml

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,12 @@
         "cs-fixer": [
             "php-cs-fixer fix"
         ],
+        "rector-check": [
+            "rector process --dry-run"
+        ],
+        "rector-fix": [
+            "rector process"
+        ],
         "phpunit": [
             "phpunit --configuration tests/phpunit.xml"
         ],


### PR DESCRIPTION
`rector process --dry-run` will run `rector`, report anything that it wants to refactor, and exit with a non-zero status if there is anything to change. So run that in CI. It will fail the CI if rector wants to do anything.

I have run `rector` just on PHP 7.4. ~It should not matter which PHP version is actually running~. It is the settings in the `rector.php` config that really matter for it doing its thing.