### PR TITLE
chore: drop PHP 7.4 8.0 8.1 and support PHP 8.2 and up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.3', '8.4']
         coverage: ['pcov']
         code-style: ['no']
         code-analysis: ['no']
         rector-check: ['no']
         include:
-          - php-versions: '7.4'
+          - php-versions: '8.2'
             coverage: 'none'
             code-style: 'yes'
             code-analysis: 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
         rector-check: ['no']
         include:
           - php-versions: '8.2'
-            coverage: 'none'
+            coverage: 'pcov'
             code-style: 'yes'
             code-analysis: 'yes'
             rector-check: 'no'
           - php-versions: '8.5'
-            coverage: 'none'
+            coverage: 'pcov'
             code-style: 'no'
             code-analysis: 'yes'
             rector-check: 'yes'

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ composer.lock
 
 # Tests
 tests/cov/
+tests/.phpunit.cache
 tests/.phpunit.result.cache
 .php_cs.cache
 .php-cs-fixer.cache

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Build status
 
 | release | minimum PHP version |
 |---------|---------------------|
-| master  | PHP 7.4             |
+| master  | PHP 8.2             |
 | 3.0     | PHP 7.4             |
 | 2.3     | PHP 7.4             |
 | 2.2     | PHP 7.1             |

--- a/composer.json
+++ b/composer.json
@@ -37,13 +37,13 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.94",
+        "friendsofphp/php-cs-fixer": "^3.95",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/extension-installer": "^1.4",
-        "phpunit/phpunit" : "^10",
-        "rector/rector": "^2.3"
+        "phpunit/phpunit" : "^10.5",
+        "rector/rector": "^2.4"
     },
     "scripts": {
         "phpstan": [

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "homepage": "http://sabre.io/uri/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": "^7.4 || ^8.0"
+        "php": "^8.2"
     },
     "authors": [
         {
@@ -70,6 +70,9 @@
     "config": {
         "allow-plugins": {
             "phpstan/extension-installer": true
+        },
+        "platform": {
+            "php": "8.2"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/extension-installer": "^1.4",
-        "phpunit/phpunit" : "^9.6",
+        "phpunit/phpunit" : "^10",
         "rector/rector": "^2.3"
     },
     "scripts": {

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -86,7 +86,7 @@ function resolve(string $basePath, string $newPath): string
     $path = implode('/', $newPathParts);
 
     // If the source url ended with a /, we want to preserve that.
-    $newParts['path'] = 0 === strpos($path, '/') ? $path : '/'.$path;
+    $newParts['path'] = str_starts_with($path, '/') ? $path : '/'.$path;
     // From PHP 8, no "?" query at all causes 'query' to be null.
     // An empty query "http://example.com/foo?" causes 'query' to be the empty string
     if (null !== $delta['query'] && '' !== $delta['query']) {
@@ -366,15 +366,15 @@ function _parse_fallback(string $uri): array
     }
 
     // Taking off a fragment part
-    if (false !== strpos($uri, '#')) {
+    if (str_contains($uri, '#')) {
         [$uri, $result['fragment']] = explode('#', $uri, 2);
     }
     // Taking off the query part
-    if (false !== strpos($uri, '?')) {
+    if (str_contains($uri, '?')) {
         [$uri, $result['query']] = explode('?', $uri, 2);
     }
 
-    if ('///' === substr($uri, 0, 3)) {
+    if (str_starts_with($uri, '///')) {
         // The triple slash uris are a bit unusual, but we have special handling
         // for them.
         $path = substr($uri, 2);
@@ -383,7 +383,7 @@ function _parse_fallback(string $uri): array
         }
         $result['path'] = $path;
         $result['host'] = '';
-    } elseif ('//' === substr($uri, 0, 2)) {
+    } elseif (str_starts_with($uri, '//')) {
         // Uris that have an authority part.
         $regex = '%^
             //

--- a/rector.php
+++ b/rector.php
@@ -15,7 +15,7 @@ return RectorConfig::configure()
         __DIR__.'/lib',
         __DIR__.'/tests',
     ])
-    ->withPhpSets(false, false, false, false, true)
+    ->withPhpSets(false, true)
     ->withTypeCoverageLevel(0)
     ->withDeadCodeLevel(0)
     ->withCodeQualityLevel(0);

--- a/tests/Uri/BuildTest.php
+++ b/tests/Uri/BuildTest.php
@@ -25,7 +25,7 @@ class BuildTest extends TestCase
     /**
      * @return list<list<string>>
      */
-    public function buildUriData(): array
+    public static function buildUriData(): array
     {
         return [
             ['http://example.org/'],

--- a/tests/Uri/NormalizeTest.php
+++ b/tests/Uri/NormalizeTest.php
@@ -22,7 +22,7 @@ class NormalizeTest extends TestCase
     /**
      * @return list<list<string>>
      */
-    public function normalizeData(): array
+    public static function normalizeData(): array
     {
         return [
             ['https://example.org/',            'https://example.org/'],

--- a/tests/Uri/ParseTest.php
+++ b/tests/Uri/ParseTest.php
@@ -58,7 +58,7 @@ class ParseTest extends TestCase
     /**
      * @return list<list<array<string, int|string|null>|string>>
      */
-    public function parseData(): array
+    public static function parseData(): array
     {
         return [
             [
@@ -233,7 +233,7 @@ class ParseTest extends TestCase
     /**
      * @return list<list<array<string, int|string|null>|string>>
      */
-    public function windowsFormatTestCases(): array
+    public static function windowsFormatTestCases(): array
     {
         return [
             [

--- a/tests/Uri/ResolveTest.php
+++ b/tests/Uri/ResolveTest.php
@@ -24,7 +24,7 @@ class ResolveTest extends TestCase
     /**
      * @return list<list<string>>
      */
-    public function resolveData(): array
+    public static function resolveData(): array
     {
         return [
             [

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,24 +1,19 @@
 <?xml version="1.0"?>
-<phpunit
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  colors="true"
-  bootstrap="../vendor/autoload.php"
-  convertErrorsToExceptions="true"
-  convertNoticesToExceptions="true"
-  convertWarningsToExceptions="true"
-  convertDeprecationsToExceptions="true"
-  beStrictAboutTestsThatDoNotTestAnything="true"
-  beStrictAboutOutputDuringTests="true"
-  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-  >
-  <coverage includeUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">../lib/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         colors="true"
+         bootstrap="../vendor/autoload.php"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="sabre-uri">
       <directory>.</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">../lib/</directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
Fixes #137 

If we want to support only PHP 8.2 and up, then this could be the way to start. Similar code from PR #134 
And I cherry-picked the commit from #135 to get phpunit to v10.
Thanks to @DerDreschner and @ChristophWurst for the contributions. I will acknowledge in the release changelog.

From the comments in the issue, I think we agree on PHP 8.2 as the minimum.