### PR TITLE
chore: prepare release 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 ChangeLog
 =========
 
+3.1.0 (2026-04-26)
+------------------
+* #139 add rector check (@ChristophWurst @phil-davis)
+* #140 drop PHP 7.4 8.0 8.1 and support PHP 8.2 and up (@DerDreschner @ChristophWurst @phil-davis)
+
 3.0.3 (2026-04-01)
 ------------------
 
 * #124 phpstan major version 2 (@phil-davis)
 * #127 add PHP 8.5 to CI workflows (@phil-davis)
-* #133 refactor: add and apply rector (ChristophWurst)
+* #133 refactor: add and apply rector (@ChristophWurst)
 
 3.0.2 (2024-09-04)
 ------------------

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    public const VERSION = '3.0.3';
+    public const VERSION = '3.1.0';
 }


### PR DESCRIPTION
This release drops support for PHP 7.4 8.0 8.1.

The code now supports PHP 8.2 and up.