### PR TITLE
test: add failure options to phpunit10 settings

### DIFF
--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -4,6 +4,8 @@
          bootstrap="../vendor/autoload.php"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
+         failOnRisky="true"
+         failOnWarning="true"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
          cacheDirectory=".phpunit.cache">
   <testsuites>


### PR DESCRIPTION
set options failOnRisky and failOnWarning so that CI will fail in these cases. That is new phpunit behavior that needs to be set, otherwise the test suite can exit with success even though there are "risky" tests or warnings.

Similar to https://github.com/sabre-io/xml/pull/328 

Test settings only, nothing to release.