### PR TITLE
test: migrate to phpunit 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/extension-installer": "^1.4",
-        "phpunit/phpunit" : "^10.5",
+        "phpunit/phpunit" : "^11.5",
         "rector/rector": "^2.4"
     },
     "scripts": {

--- a/tests/Uri/BuildTest.php
+++ b/tests/Uri/BuildTest.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Sabre\Uri;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class BuildTest extends TestCase
 {
-    /**
-     * @dataProvider buildUriData
-     */
+    #[DataProvider('buildUriData')]
     public function testBuild(string $value): void
     {
         /** @var array<string, int|string> $parsedUrl */

--- a/tests/Uri/NormalizeTest.php
+++ b/tests/Uri/NormalizeTest.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Sabre\Uri;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class NormalizeTest extends TestCase
 {
-    /**
-     * @dataProvider normalizeData
-     */
+    #[DataProvider('normalizeData')]
     public function testNormalize(string $in, string $out): void
     {
         self::assertEquals(

--- a/tests/Uri/ParseTest.php
+++ b/tests/Uri/ParseTest.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Sabre\Uri;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class ParseTest extends TestCase
 {
     /**
-     * @dataProvider parseData
-     * @dataProvider windowsFormatTestCases
-     *
      * @param list<list<array<string, int|string|null>|string>> $out
      */
+    #[DataProvider('windowsFormatTestCases')]
+    #[DataProvider('parseData')]
     public function testParse(string $in, array $out): void
     {
         self::assertEquals(
@@ -23,11 +23,10 @@ class ParseTest extends TestCase
     }
 
     /**
-     * @dataProvider parseData
-     * @dataProvider windowsFormatTestCases
-     *
      * @param list<list<array<string, int|string|null>|string>> $out
      */
+    #[DataProvider('windowsFormatTestCases')]
+    #[DataProvider('parseData')]
     public function testParseFallback(string $in, array $out): void
     {
         $result = _parse_fallback($in);

--- a/tests/Uri/ResolveTest.php
+++ b/tests/Uri/ResolveTest.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Sabre\Uri;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class ResolveTest extends TestCase
 {
     /**
-     * @dataProvider resolveData
-     *
      * @throws InvalidUriException
      */
+    #[DataProvider('resolveData')]
     public function testResolve(string $base, string $update, string $expected): void
     {
         self::assertEquals(


### PR DESCRIPTION
convert test annotations to PHP attributes

The XML schema is the same for PHPunit 10 and 11,
so that does not need to be migrated.